### PR TITLE
Temporarily skip Windows code signing (expired SSL.com cert)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -297,7 +297,11 @@ jobs:
           wails build -platform windows/amd64 -clean -skipbindings `
             -ldflags "-s -w -X github.com/SafetyCulture/mitti-exporter-ui/internal/version.version=${{ github.ref_name }}"
 
+      # TODO: re-enable once the SSL.com code-signing certificate tied to
+      # CREDENTIAL_ID is renewed - it expired and is blocking releases
+      # ("Error: certificate associated with credentialID is expired").
       - name: Sign with CodeSignTool
+        if: false
         uses: sslcom/esigner-codesign@v1.3.2
         with:
           command: sign
@@ -311,7 +315,7 @@ jobs:
           signing_method: v2
           jvm_max_memory: 1024M
 
-      - name: Copy signed binary
+      - name: Copy binary (unsigned - see TODO above)
         shell: pwsh
         run: |
           Copy-Item -Path .\ui\build\bin\mitti-exporter-ui.exe -Destination .\mitti-exporter-ui-windows-x86_64.exe


### PR DESCRIPTION
## Summary

The `v6.0.0` release is currently stuck: the `UI Windows (amd64)` job fails at the code-signing step with:
```
Error: certificate associated with credentialID is expired
```

This is unrelated to the Mitti rebrand (#510) or any code change here — the same `CREDENTIAL_ID` cert signed the `v5.0.0` release successfully back in April. The certificate itself has expired and needs renewal on the SSL.com side (org-level access, not something fixable from this repo).

This PR disables the signing step (`if: false`, left in place with a TODO comment) so releases aren't blocked while that gets sorted out. The Windows UI `.exe` ships **unsigned** in the meantime, meaning Windows SmartScreen will show an "unknown publisher" warning for users until signing is restored.

## Follow-up required
- Renew the SSL.com code-signing certificate for `CREDENTIAL_ID`.
- Re-enable this step (flip `if: false` back off) once that's done.
- Windows CLI/UI builds elsewhere aren't affected — only this one job's signing step.

## Test plan
- [x] Validated the workflow YAML is well-formed
- [ ] Not run through an actual release yet — will confirm once merged and re-tagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)