### PR TITLE
docs: fix copy-paste doc comments and incomplete DB error message

### DIFF
--- a/cli/pkg/internal/feed/feed_action.go
+++ b/cli/pkg/internal/feed/feed_action.go
@@ -197,7 +197,7 @@ func (f *ActionFeed) processDeletedActions(ctx context.Context, apiClient *httpa
 			if err != nil {
 				return events.NewEventErrorWithMessage(err,
 					events.ErrorSeverityWarning, events.ErrorSubSystemDB, false,
-					"unable to database records")
+					"unable to update database records")
 			}
 			lg.Infof("there were %d rows marked as deleted", rowsUpdated)
 		}

--- a/cli/pkg/internal/feed/feed_inspection.go
+++ b/cli/pkg/internal/feed/feed_inspection.go
@@ -344,7 +344,7 @@ func (f *InspectionFeed) processDeletedInspections(ctx context.Context, apiClien
 			if err != nil {
 				return events.NewEventErrorWithMessage(err,
 					events.ErrorSeverityWarning, events.ErrorSubSystemDB, false,
-					"unable to database records")
+					"unable to update database records")
 			}
 			lg.Infof("there were %d rows marked as deleted", rowsUpdated)
 		}

--- a/cli/pkg/internal/feed/feed_sheqsy_activity.go
+++ b/cli/pkg/internal/feed/feed_sheqsy_activity.go
@@ -16,7 +16,7 @@ import (
 	"github.com/tidwall/sjson"
 )
 
-// SheqsyActivity represents a user in sheqsy
+// SheqsyActivity represents an activity in sheqsy
 type SheqsyActivity struct {
 	ActivityUID             string    `json:"activityUId" csv:"activity_uid" gorm:"primarykey;column:activity_uid;size:36"`
 	ActivityID              int       `json:"activityId" csv:"activity_id" gorm:"column:activity_id"`
@@ -44,7 +44,7 @@ type SheqsyActivity struct {
 	ExportedAt              time.Time `json:"exported_at" csv:"exported_at" gorm:"autoUpdateTime"`
 }
 
-// SheqsyActivityFeed is a representation of the users feed
+// SheqsyActivityFeed is a representation of the activities feed
 type SheqsyActivityFeed struct{}
 
 // Name is the name of the feed

--- a/cli/pkg/internal/feed/feed_sheqsy_department.go
+++ b/cli/pkg/internal/feed/feed_sheqsy_department.go
@@ -13,7 +13,7 @@ import (
 	"github.com/SafetyCulture/mitti-exporter/pkg/internal/events"
 )
 
-// SheqsyDepartment represents a user in sheqsy
+// SheqsyDepartment represents a department in sheqsy
 type SheqsyDepartment struct {
 	DepartmentUID string    `json:"departmentUId" csv:"department_uid" gorm:"primarykey;column:department_uid;size:36"`
 	DepartmentID  int       `json:"departmentId" csv:"department_id" gorm:"column:department_id"`
@@ -24,7 +24,7 @@ type SheqsyDepartment struct {
 	ExportedAt    time.Time `json:"exported_at" csv:"exported_at" gorm:"autoUpdateTime"`
 }
 
-// SheqsyDepartmentFeed is a representation of the users feed
+// SheqsyDepartmentFeed is a representation of the departments feed
 type SheqsyDepartmentFeed struct{}
 
 // Name is the name of the feed

--- a/cli/pkg/internal/feed/feed_sheqsy_department_employee.go
+++ b/cli/pkg/internal/feed/feed_sheqsy_department_employee.go
@@ -13,7 +13,7 @@ import (
 	"github.com/SafetyCulture/mitti-exporter/pkg/internal/events"
 )
 
-// SheqsyDepartmentEmployee represents a user in sheqsy
+// SheqsyDepartmentEmployee represents a department employee in sheqsy
 type SheqsyDepartmentEmployee struct {
 	EmployeeUID   string    `json:"employeeUId" csv:"employee_uid" gorm:"primaryKey;column:employee_uid;size:36"`
 	DepartmentUID string    `json:"departmentUId" csv:"department_uid" gorm:"primaryKey;column:department_uid;size:36"`
@@ -22,7 +22,7 @@ type SheqsyDepartmentEmployee struct {
 	ExportedAt    time.Time `json:"exported_at" csv:"exported_at" gorm:"autoUpdateTime"`
 }
 
-// SheqsyDepartmentEmployeeFeed is a representation of the users feed
+// SheqsyDepartmentEmployeeFeed is a representation of the department employees feed
 type SheqsyDepartmentEmployeeFeed struct{}
 
 // Name is the name of the feed

--- a/cli/pkg/internal/feed/feed_sheqsy_shift.go
+++ b/cli/pkg/internal/feed/feed_sheqsy_shift.go
@@ -16,7 +16,7 @@ import (
 	"github.com/tidwall/sjson"
 )
 
-// SheqsyShift represents a user in sheqsy
+// SheqsyShift represents a shift in sheqsy
 type SheqsyShift struct {
 	ShiftID               int       `json:"shiftId" csv:"shift_id" gorm:"primarykey;column:shift_id;"`
 	EmployeeName          string    `json:"employeeName" csv:"employee_name" gorm:"column:employee_name"`
@@ -32,7 +32,7 @@ type SheqsyShift struct {
 	Departments           string    `json:"departments" csv:"departments" gorm:"column:departments"`
 }
 
-// SheqsyShiftFeed is a representation of the users feed
+// SheqsyShiftFeed is a representation of the shifts feed
 type SheqsyShiftFeed struct{}
 
 // Name is the name of the feed

--- a/cli/pkg/internal/feed/feed_site_member.go
+++ b/cli/pkg/internal/feed/feed_site_member.go
@@ -20,7 +20,7 @@ type SiteMember struct {
 	ExportedAt time.Time `json:"exported_at" csv:"exported_at" gorm:"autoUpdateTime"`
 }
 
-// SiteMemberFeed is a representation of the sites feed
+// SiteMemberFeed is a representation of the site members feed
 type SiteMemberFeed struct {
 }
 


### PR DESCRIPTION
## Summary

Fixes a set of copy-paste doc comments in the `feed` package plus one incomplete error message that appears twice. No functional changes beyond the two error-message strings.

### From the original report

- **cli/pkg/internal/feed/feed_sheqsy_activity.go**: `// SheqsyActivity represents a user in sheqsy` -> `represents an activity in sheqsy`
- **cli/pkg/internal/feed/feed_sheqsy_shift.go**: `// SheqsyShift represents a user in sheqsy` -> `represents a shift in sheqsy`
- **cli/pkg/internal/feed/feed_action.go**: `"unable to database records"` -> `"unable to update database records"` (the failing call is `exporter.UpdateRows`, so the missing verb is "update")

### Additional occurrences found while checking the above

These were not in the original report. They are the same two bugs in neighbouring files, and fixing only some of them would have left the package inconsistent:

- **cli/pkg/internal/feed/feed_inspection.go**: the identical `"unable to database records"` message on the identical `exporter.UpdateRows` failure path
- **cli/pkg/internal/feed/feed_sheqsy_department.go**: `represents a user in sheqsy` -> `a department`; `representation of the users feed` -> `the departments feed`
- **cli/pkg/internal/feed/feed_sheqsy_department_employee.go**: `represents a user in sheqsy` -> `a department employee`; `representation of the users feed` -> `the department employees feed`
- **cli/pkg/internal/feed/feed_sheqsy_activity.go**: `representation of the users feed` -> `the activities feed`
- **cli/pkg/internal/feed/feed_sheqsy_shift.go**: `representation of the users feed` -> `the shifts feed`
- **cli/pkg/internal/feed/feed_site_member.go**: `// SiteMemberFeed is a representation of the sites feed` -> `the site members feed`

Each replacement is taken from the type's own `Name()` return value (`sheqsy_activities`, `sheqsy_shifts`, `sheqsy_departments`, `sheqsy_department_employees`, `site_members`).

### Deliberately left unchanged

`feed_sheqsy_employee.go` keeps both of its comments. `SheqsyEmployee` really does represent a user, and it is evidently the file the others were copied from.

### Please review carefully

The two error-message changes touch runtime strings rather than comments. I grepped the repo and neither string is asserted on in any test, but they are user-visible in exporter output.

No identifiers, struct tags, or behaviour were changed.